### PR TITLE
Add Channel Name to Email

### DIFF
--- a/mailonmsg.py
+++ b/mailonmsg.py
@@ -120,5 +120,5 @@ class mailonmsg(znc.Module):
     @catchfail
     def OnChanMsg(self, nick, channel, msg):
         if self._highlight(msg.s):
-            self.send_email(nick.GetNick(), msg.s)
+            self.send_email(nick.GetNick(), str(channel)+": " + msg.s)
         return znc.CONTINUE


### PR DESCRIPTION
When users where msging me from a channel, I couldn't tell which channel or whether it was from a PM so I added the channel to the email.

Thanks for writing this! You beat me by 5 days, I was going to write this exact same script!
